### PR TITLE
fix: tenant attribute filter for tenant isolation

### DIFF
--- a/__tests__/unit/provider.test.ts
+++ b/__tests__/unit/provider.test.ts
@@ -219,6 +219,9 @@ describe('Keycloak Provider - Admin API Methods', () => {
       disableableCredentialTypes: [],
       requiredActions: [],
       notBefore: 0,
+      attributes: {
+        TENANT_ID: ['tenant_value_005'],
+      },
     },
   ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.7",
+  "version": "4.0.0-rc.8",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/src/interfaces/iKeycloakGroup.ts
+++ b/src/interfaces/iKeycloakGroup.ts
@@ -41,4 +41,8 @@ export interface KeycloakGroupMember {
   disableableCredentialTypes: string[];
   requiredActions: string[];
   notBefore: number;
+  attributes?: {
+    TENANT_ID?: string[];
+    [key: string]: string[] | undefined;
+  };
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -194,7 +194,8 @@ class KeycloakProvider implements TazamaAuthProvider<[string, string]> {
         throw new Error(`No sub-group found with role: ${roleName}`);
       }
       const subGroupMembers = await this.fetchSubGroupMembers(decodedToken, subGroupId);
-      return subGroupMembers.map((member) => this.mapToTazamaUser(member));
+      const tenantMembers = subGroupMembers.filter((member) => member.attributes?.TENANT_ID?.includes(decodedToken.tenantId));
+      return tenantMembers.map((member) => this.mapToTazamaUser(member));
     } catch (error) {
       const err = error as Error;
       throw new Error('getUsersByRole retrieval failed', { cause: err });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,13 +2,19 @@ const adminBase = (baseUrl: string, realm: string): string => `${baseUrl}/admin/
 
 export const KEYCLOAK_TOKEN_ENDPOINT = (baseUrl: string, realm: string): string =>
   `${baseUrl}/realms/${realm}/protocol/openid-connect/token`;
+
 export const KEYCLOAK_GROUP_SEARCH_ENDPOINT = (baseUrl: string, realm: string, userGroup: string): string =>
   `${adminBase(baseUrl, realm)}/groups?search=${encodeURIComponent(userGroup)}&briefRepresentation=false`;
+
 export const KEYCLOAK_GROUPS_ENDPOINT = (baseUrl: string, realm: string): string => `${adminBase(baseUrl, realm)}/groups`;
+
 export const KEYCLOAK_GROUP_MEMBERS_ENDPOINT = (baseUrl: string, realm: string, groupId: string): string =>
   `${adminBase(baseUrl, realm)}/groups/${groupId}/members`;
+
 export const KEYCLOAK_SUBGROUPS_ENDPOINT = (baseUrl: string, realm: string, groupId: string): string =>
-  `${adminBase(baseUrl, realm)}/groups/${groupId}/children`;
+  `${adminBase(baseUrl, realm)}/groups/${groupId}/children?briefRepresentation=false`;
+
 export const KEYCLOAK_USERS_ENDPOINT = (baseUrl: string, realm: string): string => `${adminBase(baseUrl, realm)}/users`;
+
 export const KEYCLOAK_SUBGROUP_MEMBERS_ENDPOINT = (baseUrl: string, realm: string, subGroupId: string): string =>
-  `${adminBase(baseUrl, realm)}/groups/${subGroupId}/members`;
+  `${adminBase(baseUrl, realm)}/groups/${subGroupId}/members?briefRepresentation=false`;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
- Updated the KeycloakGroupMember interface to contain user attributes.
- Added `briefRepresentation=false` to ENDPOINT constants
- Added a filter of tenant attribute for the group members

## Why are we doing this?
- Fix tenant isolation issues as reported in the [Issue](https://github.com/tazama-lf/auth-service/issues/180)

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user filtering to properly respect tenant boundaries when retrieving group members, ensuring users only see data relevant to their assigned tenant.

* **Chores**
  * Version bumped to 4.0.0-rc.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->