### PR TITLE
fix: paysys/auth tenant fix

### DIFF
--- a/__tests__/unit/provider.test.ts
+++ b/__tests__/unit/provider.test.ts
@@ -184,9 +184,6 @@ describe('Keycloak Provider - Admin API Methods', () => {
       name: 'test-group',
       path: '/test-group',
       subGroupCount: 2,
-      attributes: {
-        TENANT_ID: ['tenant_value_005'],
-      },
     },
   ];
 
@@ -196,12 +193,18 @@ describe('Keycloak Provider - Admin API Methods', () => {
       name: 'admin-role',
       path: '/test-group/admin-role',
       realmRoles: ['admin-role'],
+      attributes: {
+        TENANT_ID: ['tenant_value_005'],
+      },
     },
     {
       id: 'subgroup-2',
       name: 'user-role',
       path: '/test-group/user-role',
       realmRoles: ['user-role'],
+      attributes: {
+        TENANT_ID: ['tenant_value_005'],
+      },
     },
   ];
 

--- a/__tests__/unit/provider.test.ts
+++ b/__tests__/unit/provider.test.ts
@@ -218,6 +218,17 @@ describe('Keycloak Provider - Admin API Methods', () => {
     },
   ];
 
+  const mockUserRoleTenantSubGroups = [
+    {
+      id: 'tenant-subgroup-2',
+      name: 'tenant_value_005',
+      path: '/test-group/user-role/tenant_value_005',
+      attributes: {
+        TENANT_ID: ['tenant_value_005'],
+      },
+    },
+  ];
+
   const mockMembers = [
     {
       id: 'user-1',
@@ -461,9 +472,10 @@ describe('Keycloak Provider - Admin API Methods', () => {
         }),
       );
 
-    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'non-existent-role')).rejects.toThrow(
-      'getUsersByRole retrieval failed',
-    );
+    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'non-existent-role')).rejects.toMatchObject({
+      message: 'getUsersByRole retrieval failed',
+      cause: { message: 'No sub-group found with role: non-existent-role' },
+    });
   });
 
   it('should throw error when no sub-group with matching role found', async () => {
@@ -509,7 +521,7 @@ describe('Keycloak Provider - Admin API Methods', () => {
         }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(mockTenantSubGroups), {
+        new Response(JSON.stringify(mockUserRoleTenantSubGroups), {
           status: 200,
         }),
       )
@@ -521,6 +533,14 @@ describe('Keycloak Provider - Admin API Methods', () => {
 
     const result = await provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'user-role');
     expect(result).toEqual(mockTazamaMembers);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('/groups/subgroup-2/children'),
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: 'Bearer test-token-string' },
+      }),
+    );
   });
 
   it('should handle fetch timeout/abort scenarios', async () => {
@@ -590,7 +610,10 @@ describe('Keycloak Provider - Admin API Methods', () => {
         }),
       );
 
-    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'admin-role')).rejects.toThrow('getUsersByRole retrieval failed');
+    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'admin-role')).rejects.toMatchObject({
+      message: 'getUsersByRole retrieval failed',
+      cause: { message: 'No tenant sub-group found for tenant: tenant_value_005' },
+    });
   });
 
   it('should map Keycloak user to TazamaUser correctly', async () => {

--- a/__tests__/unit/provider.test.ts
+++ b/__tests__/unit/provider.test.ts
@@ -88,13 +88,13 @@ describe('Keycloak Provider', () => {
     jest.spyOn(jwt, 'decode').mockRestore();
   });
 
-  it('should handle token with missing optional fields (sid, tenant_id)', async () => {
+  it('should throw error when tenant_id is missing from token', async () => {
     jest.spyOn(jwt, 'decode').mockImplementationOnce(() => {
       return {
         sub: '687488800-fc3a-4425-977c-ed58f1afb7cd', // Required field
         iss: 'http://localhost:8080/realms/tazama', // Required field
         exp: 1753094140, // Required field
-        // sid and tenant_id are missing to test fallback values
+        // tenant_id is missing - should cause an error
         resource_access: {
           account: { roles: ['manage-account'] },
         },
@@ -105,9 +105,14 @@ describe('Keycloak Provider', () => {
     });
 
     const provider = new KeycloakProvider();
-    const token = await provider.getToken('testUser', 'testPassword');
 
-    expect(token).toEqual(jwtSignVal);
+    try {
+      await provider.getToken('testUser', 'testPassword');
+      throw new Error('UNREACHABLE');
+    } catch (err) {
+      expect(err).toEqual(new Error('Token is missing required tenant_id claim'));
+    }
+
     jest.spyOn(jwt, 'decode').mockRestore();
   });
 
@@ -193,15 +198,20 @@ describe('Keycloak Provider - Admin API Methods', () => {
       name: 'admin-role',
       path: '/test-group/admin-role',
       realmRoles: ['admin-role'],
-      attributes: {
-        TENANT_ID: ['tenant_value_005'],
-      },
     },
     {
       id: 'subgroup-2',
       name: 'user-role',
       path: '/test-group/user-role',
       realmRoles: ['user-role'],
+    },
+  ];
+
+  const mockTenantSubGroups = [
+    {
+      id: 'tenant-subgroup-1',
+      name: 'tenant_value_005',
+      path: '/test-group/admin-role/tenant_value_005',
       attributes: {
         TENANT_ID: ['tenant_value_005'],
       },
@@ -365,7 +375,7 @@ describe('Keycloak Provider - Admin API Methods', () => {
   it('should fetch users by role successfully', async () => {
     const provider = new KeycloakProvider();
 
-    // Mock the three fetch calls needed for fetchUsersByRole
+    // Mock the four fetch calls needed for fetchUsersByRole
     jest
       .spyOn(global, 'fetch')
       .mockResolvedValueOnce(
@@ -375,6 +385,11 @@ describe('Keycloak Provider - Admin API Methods', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockSubGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTenantSubGroups), {
           status: 200,
         }),
       )
@@ -494,6 +509,11 @@ describe('Keycloak Provider - Admin API Methods', () => {
         }),
       )
       .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTenantSubGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
         new Response(JSON.stringify(mockMembers), {
           status: 200,
         }),
@@ -510,5 +530,127 @@ describe('Keycloak Provider - Admin API Methods', () => {
     jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('The operation was aborted'));
 
     await expect(provider.fetchUserGroupDetails(mockTazamaToken, 'test-group')).rejects.toThrow('fetchUserGroupDetails retrieval failed');
+  });
+
+  it('should throw error when no matching role group found', async () => {
+    const provider = new KeycloakProvider();
+    const subGroupsWithoutMatchingRole = [
+      {
+        id: 'subgroup-other',
+        name: 'other-role',
+        path: '/test-group/other-role',
+        realmRoles: ['other-role'],
+      },
+    ];
+
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(subGroupsWithoutMatchingRole), {
+          status: 200,
+        }),
+      );
+
+    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'admin-role')).rejects.toThrow('getUsersByRole retrieval failed');
+  });
+
+  it('should throw error when tenant subgroup not found', async () => {
+    const provider = new KeycloakProvider();
+    const tenantSubGroupsWithWrongTenant = [
+      {
+        id: 'tenant-subgroup-wrong',
+        name: 'different_tenant',
+        path: '/test-group/admin-role/different_tenant',
+        attributes: {
+          TENANT_ID: ['different_tenant_id'],
+        },
+      },
+    ];
+
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockSubGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(tenantSubGroupsWithWrongTenant), {
+          status: 200,
+        }),
+      );
+
+    await expect(provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'admin-role')).rejects.toThrow('getUsersByRole retrieval failed');
+  });
+
+  it('should map Keycloak user to TazamaUser correctly', async () => {
+    const provider = new KeycloakProvider();
+    const memberWithAllFields = {
+      id: 'user-complete',
+      username: 'complete.user',
+      email: 'complete@example.com',
+      firstName: 'Complete',
+      lastName: 'User',
+      emailVerified: true,
+      enabled: true,
+      createdTimestamp: 9876543210,
+      totp: true,
+      disableableCredentialTypes: ['password'],
+      requiredActions: ['UPDATE_PASSWORD'],
+      notBefore: 12345,
+    };
+
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockSubGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTenantSubGroups), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([memberWithAllFields]), {
+          status: 200,
+        }),
+      );
+
+    const result = await provider.fetchUsersByRole(mockTazamaToken, 'test-group', 'admin-role');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'user-complete',
+      username: 'complete.user',
+      email: 'complete@example.com',
+      firstName: 'Complete',
+      lastName: 'User',
+      emailVerified: true,
+      enabled: true,
+      createdTimestamp: 9876543210,
+      metadata: {
+        totp: true,
+        disableableCredentialTypes: ['password'],
+        requiredActions: ['UPDATE_PASSWORD'],
+        notBefore: 12345,
+      },
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.13",
+  "version": "4.0.0-rc.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib-provider-keycloak",
-      "version": "4.0.0-rc.13",
+      "version": "4.0.0-rc.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "4.0.0-rc.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.11",
+  "version": "4.0.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib-provider-keycloak",
-      "version": "4.0.0-rc.11",
+      "version": "4.0.0-rc.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "^4.0.0-rc.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0-rc.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/auth-lib": "^4.0.0-rc.4"
+        "@tazama-lf/auth-lib": "4.0.0-rc.5"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@tazama-lf/auth-lib": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib/4.0.0-rc.4/bd1087315ca3f9937e3c8fcaec0b194274620a53",
-      "integrity": "sha512-NOf55XmNZPqQT819Y+Difh4QJgsEmLSBCt6ba3lBcbGRRIlX4wERi7mJ9uiL5AvCUiEcog1Sl4AggyGpZ2dSRQ==",
+      "version": "4.0.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib/4.0.0-rc.5/5912b13690ac3b357adf241844601827133e4751",
+      "integrity": "sha512-Mr0toDyjw3hytVX1Y5MLc26LGiaWN0H6d6QJU3L8mRZIo763vAH9dGG6cSRi288f+fNHR0wKmM+nVJ4eWgNZ/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.12",
+  "version": "4.0.0-rc.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib-provider-keycloak",
-      "version": "4.0.0-rc.12",
+      "version": "4.0.0-rc.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "4.0.0-rc.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.6",
+  "version": "4.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib-provider-keycloak",
-      "version": "4.0.0-rc.6",
+      "version": "4.0.0-rc.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "^4.0.0-rc.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.10",
+  "version": "4.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib-provider-keycloak",
-      "version": "4.0.0-rc.10",
+      "version": "4.0.0-rc.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "^4.0.0-rc.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.8",
+  "version": "4.0.0-rc.10",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.13",
+  "version": "4.0.0-rc.14",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.10",
+  "version": "4.0.0-rc.11",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.11",
+  "version": "4.0.0-rc.12",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib-provider-keycloak",
-  "version": "4.0.0-rc.12",
+  "version": "4.0.0-rc.13",
   "description": "Keycloak provider for auth-lib",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@tazama-lf/auth-lib": "^4.0.0-rc.4"
+    "@tazama-lf/auth-lib": "4.0.0-rc.5"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/src/interfaces/iKeycloakGroup.ts
+++ b/src/interfaces/iKeycloakGroup.ts
@@ -25,6 +25,7 @@ export interface KeycloakGroup {
 export interface KeycloakSubGroup extends KeycloakGroup {
   parentId?: string;
   realmRoles?: string[];
+  attributes?: GroupAttribute;
   clientRoles?: Record<string, string[]>;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -189,13 +189,13 @@ class KeycloakProvider implements TazamaAuthProvider<[string, string]> {
         throw new Error(`No group found with the group name: ${userGroup}`);
       }
       const subGroups = await this.fetchSubGroups(decodedToken, groupDetails[FIRST_INDEX].id ?? '');
-      const subGroupId = subGroups.find((group: KeycloakSubGroup) => group.realmRoles?.includes(roleName))?.id;
+      const tenantSpecificSubGroups = subGroups.filter((group) => group.attributes?.TENANT_ID?.includes(decodedToken.tenantId));
+      const subGroupId = tenantSpecificSubGroups.find((group: KeycloakSubGroup) => group.name === roleName)?.id;
       if (!subGroupId) {
         throw new Error(`No sub-group found with role: ${roleName}`);
       }
       const subGroupMembers = await this.fetchSubGroupMembers(decodedToken, subGroupId);
-      const tenantMembers = subGroupMembers.filter((member) => member.attributes?.TENANT_ID?.includes(decodedToken.tenantId));
-      return tenantMembers.map((member) => this.mapToTazamaUser(member));
+      return subGroupMembers.map((member) => this.mapToTazamaUser(member));
     } catch (error) {
       const err = error as Error;
       throw new Error('getUsersByRole retrieval failed', { cause: err });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -79,6 +79,11 @@ class KeycloakProvider implements TazamaAuthProvider<[string, string]> {
       throw new Error(`Token is missing required properties: sub: ${decodedToken.sub}, iss: ${decodedToken.iss}, exp: ${decodedToken.exp}`);
     }
 
+    // Ensure tenant_id is present - if missing, the user is misconfigured in Keycloak
+    if (!decodedToken.tenant_id) {
+      throw new Error('Token is missing required tenant_id claim');
+    }
+
     decodedToken.sid ??= 'auth-lib-provider-keycloak';
 
     return {
@@ -88,7 +93,7 @@ class KeycloakProvider implements TazamaAuthProvider<[string, string]> {
       exp: decodedToken.exp,
       tokenString: authToken.accessToken,
       claims: this.mapTazamaRoles(decodedToken), // Pass the typed token here
-      tenantId: decodedToken.tenant_id ?? 'DEFAULT',
+      tenantId: decodedToken.tenant_id,
     };
   }
 
@@ -188,13 +193,25 @@ class KeycloakProvider implements TazamaAuthProvider<[string, string]> {
       if (groupDetails.length === ZERO) {
         throw new Error(`No group found with the group name: ${userGroup}`);
       }
-      const subGroups = await this.fetchSubGroups(decodedToken, groupDetails[FIRST_INDEX].id ?? '');
-      const tenantSpecificSubGroups = subGroups.filter((group) => group.attributes?.TENANT_ID?.includes(decodedToken.tenantId));
-      const subGroupId = tenantSpecificSubGroups.find((group: KeycloakSubGroup) => group.name === roleName)?.id;
-      if (!subGroupId) {
+
+      // Tier 2 - Get role groups
+      const tier2Groups = await this.fetchSubGroups(decodedToken, groupDetails[FIRST_INDEX].id ?? '');
+      const roleGroup = tier2Groups.find((group: KeycloakSubGroup) => group.name === roleName);
+
+      if (!roleGroup?.id) {
         throw new Error(`No sub-group found with role: ${roleName}`);
       }
-      const subGroupMembers = await this.fetchSubGroupMembers(decodedToken, subGroupId);
+
+      // Tier 3 - Get tenant subgroups under the role group
+      const tier3Groups = await this.fetchSubGroups(decodedToken, roleGroup.id);
+      const tenantGroup = tier3Groups.find((group: KeycloakSubGroup) => group.attributes?.TENANT_ID?.includes(decodedToken.tenantId));
+
+      if (!tenantGroup?.id) {
+        throw new Error(`No tenant sub-group found for tenant: ${decodedToken.tenantId}`);
+      }
+
+      // Get members from the tenant-specific subgroup
+      const subGroupMembers = await this.fetchSubGroupMembers(decodedToken, tenantGroup.id);
       return subGroupMembers.map((member) => this.mapToTazamaUser(member));
     } catch (error) {
       const err = error as Error;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,7 +12,7 @@ export const KEYCLOAK_GROUP_MEMBERS_ENDPOINT = (baseUrl: string, realm: string, 
   `${adminBase(baseUrl, realm)}/groups/${groupId}/members`;
 
 export const KEYCLOAK_SUBGROUPS_ENDPOINT = (baseUrl: string, realm: string, groupId: string): string =>
-  `${adminBase(baseUrl, realm)}/groups/${groupId}/children?briefRepresentation=false`;
+  `${adminBase(baseUrl, realm)}/groups/${groupId}/children?briefRepresentation=false&max=100`;
 
 export const KEYCLOAK_USERS_ENDPOINT = (baseUrl: string, realm: string): string => `${adminBase(baseUrl, realm)}/users`;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,7 +12,7 @@ export const KEYCLOAK_GROUP_MEMBERS_ENDPOINT = (baseUrl: string, realm: string, 
   `${adminBase(baseUrl, realm)}/groups/${groupId}/members`;
 
 export const KEYCLOAK_SUBGROUPS_ENDPOINT = (baseUrl: string, realm: string, groupId: string): string =>
-  `${adminBase(baseUrl, realm)}/groups/${groupId}/children?briefRepresentation=false&max=100`;
+  `${adminBase(baseUrl, realm)}/groups/${groupId}/children?briefRepresentation=false&first=0&max=100`;
 
 export const KEYCLOAK_USERS_ENDPOINT = (baseUrl: string, realm: string): string => `${adminBase(baseUrl, realm)}/users`;
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Implemented 3 Tier traversal for sub-group

## Why are we doing this?
Bug-fix to traverse to Tier 3

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token validation now requires a tenant identifier claim
  * Improved tenant-scoped lookup when resolving users by role

* **Tests**
  * Expanded coverage for token validation, role lookup failures, tenant-scoped errors, and user data mapping

* **Chores**
  * Package bumped to 4.0.0-rc.13
  * Authentication library updated to 4.0.0-rc.5
<!-- end of auto-generated comment: release notes by coderabbit.ai -->